### PR TITLE
Rename connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Aiven Kafka HTTP Connector
+# Kafka HTTP Connector
 
 [![Build Status](https://travis-ci.org/aiven/aiven-kafka-connect-http.svg?branch=master)](https://travis-ci.org/aiven/aiven-kafka-connect-http)
 


### PR DESCRIPTION
It's incorrect to say `Aiven Kafka HTTP Connector` for the trademark reason.